### PR TITLE
Command Line Interface

### DIFF
--- a/bin/shepherd
+++ b/bin/shepherd
@@ -1,0 +1,3 @@
+#!/usr/bin/env php
+<?php
+require_once 'shepherd.php';

--- a/bin/shepherd.php
+++ b/bin/shepherd.php
@@ -65,11 +65,19 @@ if (!($class instanceof CommandInterface)) {
 
 // Use GetOpt to process the arguments properly:
 $getOpt = new GetOpt($class->getOptions());
-$getOpt->process($args);
+$getOpt->addOperands($class->getOperands());
+try {
+    $getOpt->process($args);
+} catch (\GetOpt\ArgumentException $ex) {
+    echo 'Error (', \get_class($ex), '): ',
+        $ex->getMessage(), PHP_EOL;
+    exit(1);
+}
 $opts = $getOpt->getOptions();
+$operands = $getOpt->getOperands();
 
 // Execute the CLI command.
 $exitCode = $class
     ->setOpts($opts)
-    ->run(...$args);
+    ->run(...$operands);
 exit($exitCode);

--- a/bin/shepherd.php
+++ b/bin/shepherd.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+require_once \dirname(__DIR__) . '/vendor/autoload.php';
+
+use GetOpt\GetOpt;
+use ParagonIE\Herd\CommandLine\Command\{
+    AddRemote,
+    Fact,
+    Help,
+    GetUpdate,
+    ListProducts,
+    ListUpdates,
+    ListVendors,
+    Transcribe,
+    VendorKeys
+};
+use ParagonIE\Herd\CommandLine\CommandInterface;
+
+/**
+ * CLI secondary arguments.
+ *
+ * shepherd <command> (... arguments)
+ *
+ * @var array<string, string> $commandAliases
+ */
+$commandAliases = [
+    '' => Help::class,
+    'add-remote' => AddRemote::class,
+    'fact' => Fact::class,
+    'get-update' => GetUpdate::class,
+    'help'  => Help::class,
+    'list-products' => ListProducts::class,
+    'list-updates' => ListUpdates::class,
+    'list-vendors' => ListVendors::class,
+    'transcribe' => Transcribe::class,
+    'vendor-keys' => VendorKeys::class
+];
+
+/** Do not touch the code below this line unless you absolutely must. **/
+
+// Which command is being executed?
+if ($argv[0] === 'php') {
+    $alias = $argc > 2 ? $argv[2] : '';
+    $args = \array_slice($argv, 3);
+} else {
+    $alias = $argc > 1 ? $argv[1] : '';
+    $args = \array_slice($argv, 2);
+}
+
+if (!array_key_exists($alias, $commandAliases)) {
+    echo 'Command not found!', PHP_EOL;
+    exit(255);
+}
+$command = $commandAliases[$alias];
+if (!\class_exists($command)) {
+    echo 'Command not found! (Class does not exist.)', PHP_EOL;
+    exit(255);
+}
+$class = new $command;
+if (!($class instanceof CommandInterface)) {
+    echo 'Command not an instance of CommandInterface!', PHP_EOL;
+    exit(255);
+}
+
+// Use GetOpt to process the arguments properly:
+$getOpt = new GetOpt($class->getOptions());
+$getOpt->process($args);
+$opts = $getOpt->getOptions();
+
+// Execute the CLI command.
+$exitCode = $class
+    ->setOpts($opts)
+    ->run(...$args);
+exit($exitCode);

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "paragonie/constant_time_encoding": "^2",
     "paragonie/easydb": "^2.5",
     "paragonie/sapient": "^1",
-    "paragonie/sodium_compat": "^1.4"
+    "paragonie/sodium_compat": "^1.4",
+    "ulrichsg/getopt-php": "^3"
   },
   "require-dev": {
     "phpunit/phpunit": "^6|^7",

--- a/data/config.json
+++ b/data/config.json
@@ -1,5 +1,6 @@
 {
   "core-vendor": "paragonie",
+  "database": [],
   "policies": {
     "core-vendor-manage-keys-allow": false,
     "core-vendor-manage-keys-auto": false,

--- a/src/CommandLine/Command/AddRemote.php
+++ b/src/CommandLine/Command/AddRemote.php
@@ -2,9 +2,11 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\GetOpt;
-use GetOpt\Operand;
-use GetOpt\Option;
+use GetOpt\{
+    GetOpt,
+    Operand,
+    Option
+};
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Herd\CommandLine\{
@@ -68,6 +70,7 @@ class AddRemote implements CommandInterface
         if (!\is_string($file)) {
             throw new FilesystemException('Could not read configuration file');
         }
+        /** @var array<string, array<int, array<string, string>>> $decoded */
         $decoded = \json_decode($file, true);
         if (!\is_array($decoded)) {
             throw new EncodingError('Could not decode JSON body in configuration file');
@@ -88,6 +91,7 @@ class AddRemote implements CommandInterface
             throw new EncodingError('Could not re-encode JSON body');
         }
 
+        /** @var bool|int $saved */
         $saved = \file_put_contents($this->configPath, $encoded);
         if (!\is_int($saved)) {
             throw new FilesystemException('Could not write to configuration file');
@@ -98,8 +102,9 @@ class AddRemote implements CommandInterface
     /**
      * @param string $path
      * @throws FilesystemException
+     * @return self
      */
-    public function setConfigPath(string $path)
+    public function setConfigPath(string $path): self
     {
         if (!\file_exists($path)) {
             throw new FilesystemException('Configuration file does not exist');
@@ -111,13 +116,14 @@ class AddRemote implements CommandInterface
             throw new FilesystemException('Configuration file cannot be written to by the current user');
         }
         $this->configPath = \realpath($path);
+        return $this;
     }
 
     /**
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
      * @throws FilesystemException
      */

--- a/src/CommandLine/Command/AddRemote.php
+++ b/src/CommandLine/Command/AddRemote.php
@@ -133,6 +133,23 @@ class AddRemote implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'Add remote source',
+            'usage' => 'shepherd add-remote <url> <public-key>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ],
+                'Primary?' => [
+                    'Examples' => [
+                        '-p',
+                        '--primary'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/AddRemote.php
+++ b/src/CommandLine/Command/AddRemote.php
@@ -11,7 +11,7 @@ use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
-    DatabaseTrait
+    ConfigurableTrait
 };
 use ParagonIE\Herd\Exception\EncodingError;
 use ParagonIE\Herd\Exception\FilesystemException;
@@ -22,10 +22,7 @@ use ParagonIE\Herd\Exception\FilesystemException;
  */
 class AddRemote implements CommandInterface
 {
-    use DatabaseTrait;
-
-    /** @var string $configPath */
-    protected $configPath = '';
+    use ConfigurableTrait;
 
     /** @var bool $primary */
     protected $primary = false;
@@ -36,7 +33,7 @@ class AddRemote implements CommandInterface
     public function getOptions(): array
     {
         return [
-            new Option('c', 'config', GetOpt::OPTIONAL_ARGUMENT),
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT),
             new Option('p', 'primary', GetOpt::NO_ARGUMENT)
         ];
     }
@@ -97,26 +94,6 @@ class AddRemote implements CommandInterface
             throw new FilesystemException('Could not write to configuration file');
         }
         return 0;
-    }
-
-    /**
-     * @param string $path
-     * @throws FilesystemException
-     * @return self
-     */
-    public function setConfigPath(string $path): self
-    {
-        if (!\file_exists($path)) {
-            throw new FilesystemException('Configuration file does not exist');
-        }
-        if (!\is_readable($path)) {
-            throw new FilesystemException('Configuration file cannot be read by the current user');
-        }
-        if (!\is_writable($path)) {
-            throw new FilesystemException('Configuration file cannot be written to by the current user');
-        }
-        $this->configPath = \realpath($path);
-        return $this;
     }
 
     /**

--- a/src/CommandLine/Command/AddRemote.php
+++ b/src/CommandLine/Command/AddRemote.php
@@ -2,11 +2,17 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
+use GetOpt\GetOpt;
+use GetOpt\Operand;
 use GetOpt\Option;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\ConstantTime\Binary;
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
+use ParagonIE\Herd\Exception\FilesystemException;
 
 /**
  * Class AddRemote
@@ -16,22 +22,95 @@ class AddRemote implements CommandInterface
 {
     use DatabaseTrait;
 
+    /** @var string $configPath */
+    protected $configPath = '';
+
+    /** @var bool $primary */
+    protected $primary = false;
+
     /**
      * @return array<int, Option>
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::OPTIONAL_ARGUMENT),
+            new Option('p', 'primary', GetOpt::NO_ARGUMENT)
+        ];
+    }
+
+    /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [
+            new Operand('url', Operand::REQUIRED),
+            new Operand('publickey', Operand::REQUIRED)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws EncodingError
+     * @throws FilesystemException
      */
     public function run(...$args): int
     {
+        /**
+         * @var string $url
+         * @var string $publickey
+         */
+        list ($url, $publickey) = $args;
 
+        $file = \file_get_contents($this->configPath);
+        if (!\is_string($file)) {
+            throw new FilesystemException('Could not read configuration file');
+        }
+        $decoded = \json_decode($file, true);
+        if (!\is_array($decoded)) {
+            throw new EncodingError('Could not decode JSON body in configuration file');
+        }
+        $pkey = (string) Base64UrlSafe::decode($publickey);
+        if (Binary::safeStrlen($pkey) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+            throw new EncodingError('Public key is not a base64url-encoded Ed25519 public key, but it must be.');
+        }
+
+        $decoded['remotes'][] = [
+            'url' => $url,
+            'public-key' => $publickey,
+            'primary' => $this->primary
+        ];
+
+        $encoded = \json_encode($decoded, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not re-encode JSON body');
+        }
+
+        $saved = \file_put_contents($this->configPath, $encoded);
+        if (!\is_int($saved)) {
+            throw new FilesystemException('Could not write to configuration file');
+        }
         return 0;
+    }
+
+    /**
+     * @param string $path
+     * @throws FilesystemException
+     */
+    public function setConfigPath(string $path)
+    {
+        if (!\file_exists($path)) {
+            throw new FilesystemException('Configuration file does not exist');
+        }
+        if (!\is_readable($path)) {
+            throw new FilesystemException('Configuration file cannot be read by the current user');
+        }
+        if (!\is_writable($path)) {
+            throw new FilesystemException('Configuration file cannot be written to by the current user');
+        }
+        $this->configPath = \realpath($path);
     }
 
     /**
@@ -40,9 +119,27 @@ class AddRemote implements CommandInterface
      *
      * @param array $args
      * @return self
+     * @throws FilesystemException
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
+
+        if (isset($args['primary'])) {
+            $this->primary = true;
+        } elseif (isset($args['p'])) {
+            $this->primary = true;
+        }
+
         return $this;
     }
 

--- a/src/CommandLine/Command/AddRemote.php
+++ b/src/CommandLine/Command/AddRemote.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class AddRemote
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class AddRemote implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/Fact.php
+++ b/src/CommandLine/Command/Fact.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class Fact
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class Fact implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/Fact.php
+++ b/src/CommandLine/Command/Fact.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/Fact.php
+++ b/src/CommandLine/Command/Fact.php
@@ -110,6 +110,17 @@ class Fact implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'Add remote source',
+            'usage' => 'shepherd fact <summary-hash>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/Fact.php
+++ b/src/CommandLine/Command/Fact.php
@@ -25,6 +25,14 @@ class Fact implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/Fact.php
+++ b/src/CommandLine/Command/Fact.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
+    ConfigurableTrait,
     CommandInterface,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class Fact
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class Fact implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class Fact implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,45 @@ class Fact implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('hash', Operand::REQUIRED)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        /** @var string $arg1 */
+        $arg1 = \array_shift($args);
 
+        $db = $this->getDatabase($this->configPath);
+        /** @var array<string, string> $data */
+        $data = $db->row(
+            "SELECT * FROM herd_history WHERE summaryhash = ? OR id = ?",
+            $arg1,
+            $arg1
+        );
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
+
+        // We don't need this to display:
+        unset($data['id']);
+
+        // Convert to bool
+        $data['accepted'] = !empty($data['accepted']);
+
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode fact into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +84,22 @@ class Fact implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/GetUpdate.php
+++ b/src/CommandLine/Command/GetUpdate.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/GetUpdate.php
+++ b/src/CommandLine/Command/GetUpdate.php
@@ -131,6 +131,17 @@ class GetUpdate implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'Get update information',
+            'usage' => 'shepherd get-update <vendor> <product> <version>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/GetUpdate.php
+++ b/src/CommandLine/Command/GetUpdate.php
@@ -25,6 +25,14 @@ class GetUpdate implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/GetUpdate.php
+++ b/src/CommandLine/Command/GetUpdate.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class GetUpdate
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class GetUpdate implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/GetUpdate.php
+++ b/src/CommandLine/Command/GetUpdate.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
+    ConfigurableTrait,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class GetUpdate
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class GetUpdate implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class GetUpdate implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,66 @@ class GetUpdate implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('vendor', Operand::REQUIRED),
+            new Operand('product', Operand::REQUIRED),
+            new Operand('version', Operand::REQUIRED)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        /**
+         * @var string $vendor
+         * @var string $product
+         * @var string $version
+         */
+        list($vendor, $product, $version) = $args;
+        $db = $this->getDatabase($this->configPath);
 
+        /** @var array<string, string> $data */
+        $data = $db->row(
+            "
+                SELECT
+                    v.name AS vendor,
+                    p.name AS product,
+                    h.contents AS history,
+                    h.hash,
+                    h.summaryhash,
+                    u.*
+                FROM
+                    herd_vendors v
+                LEFT JOIN
+                    herd_products p ON p.vendor = v.id
+                LEFT JOIN
+                    herd_product_updates u ON u.product = p.id
+                LEFT JOIN
+                    herd_history h ON u.history = h.id
+                WHERE
+                    v.name = ?
+                    AND p.name = ?
+                    AND u.version = ?
+            ",
+            $vendor,
+            $product,
+            $version
+        );
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
+
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode fact into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +105,22 @@ class GetUpdate implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/Help.php
+++ b/src/CommandLine/Command/Help.php
@@ -23,6 +23,14 @@ class Help implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @return array<string, array>
      */
     public function getCommands(): array

--- a/src/CommandLine/Command/Help.php
+++ b/src/CommandLine/Command/Help.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\CommandInterface;
 
 /**

--- a/src/CommandLine/Command/Help.php
+++ b/src/CommandLine/Command/Help.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\CommandInterface;
+
+/**
+ * Class Help
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class Help implements CommandInterface
+{
+    /** @var string */
+    protected $subCommand = '';
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, array>
+     */
+    public function getCommands(): array
+    {
+        /** @var array<string, string> $aliases */
+        $aliases = $GLOBALS['commandAliases'];
+        $map = [];
+        foreach ($aliases as $command => $className) {
+            if (empty($className) || empty($command)) {
+                continue;
+            }
+            if ($className === __CLASS__) {
+                $usageInfo = $this->usageInfo();
+            } else {
+                /** @var CommandInterface $class */
+                $class = new $className;
+                if (!($class instanceof CommandInterface)) {
+                    continue;
+                }
+                $usageInfo = $class->usageInfo();
+            }
+            $map[$command] = $usageInfo;
+        }
+        return $map;
+    }
+
+    /**
+     * Return the size of hte current terminal window
+     *
+     * @return array<int, int>
+     * @psalm-suppress
+     */
+    public function getScreenSize()
+    {
+        $output = [];
+        \preg_match_all(
+            "/rows.([0-9]+);.columns.([0-9]+);/",
+            \strtolower(\exec('stty -a | grep columns')),
+            $output
+        );
+        /** @var array<int, array<int, int>> $output */
+        if (\sizeof($output) === 3) {
+            /** @var array<int, int> $width */
+            $width = $output[2];
+            /** @var array<int, int> $height */
+            $height = $output[1];
+            return [
+                $width[0],
+                $height[0]
+            ];
+        }
+        return [80, 25];
+    }
+
+    /**
+     * @return int
+     */
+    public function listCommands(): int
+    {
+        $commands = $this->getCommands();
+        $maxLength = 7;
+        /** @var string $key */
+        foreach (\array_keys($commands) as $key) {
+            $maxLength = \max($maxLength, \strlen($key));
+        }
+        /**
+         * @var int $w
+         * @var int $h
+         */
+        list($w, $h) = $this->getScreenSize();
+
+        // Header
+        echo \str_pad('Command', $maxLength + 2, ' ', STR_PAD_RIGHT),
+            '| Information',
+            PHP_EOL;
+
+        /**
+         * @var string $command
+         * @var array $usageInfo
+         */
+        foreach ($commands as $command => $usageInfo) {
+            echo \str_repeat('-', $w - 1), PHP_EOL;
+            echo \str_pad($command, $maxLength + 2, ' ', STR_PAD_RIGHT),
+                '| ';
+
+            // Display format. Temporarily, JSON.
+            $encoded = \json_encode($usageInfo, JSON_PRETTY_PRINT);
+            if (!\is_string($encoded)) {
+                continue;
+            }
+            if ($encoded === '[]') {
+                echo '(No help information available.)', PHP_EOL;
+                continue;
+            }
+            $usage = \explode(PHP_EOL, $encoded);
+            echo \implode(PHP_EOL . \str_repeat(' ', $maxLength + 2 ). '| ', $usage);
+            echo PHP_EOL;
+        }
+        return 0;
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+        if (empty($args)) {
+            return $this->listCommands();
+        }
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [
+            'name' => 'Usage Information',
+            'details' => 'Learn how to use each command available to this CLI API.'
+        ];
+    }
+}

--- a/src/CommandLine/Command/Help.php
+++ b/src/CommandLine/Command/Help.php
@@ -104,7 +104,10 @@ class Help implements CommandInterface
          * @var array $usageInfo
          */
         foreach ($commands as $command => $usageInfo) {
-            echo \str_repeat('-', $w - 1), PHP_EOL;
+            echo \str_repeat('-', $maxLength + 2),
+                '+',
+                \str_repeat('-', $w - $maxLength - 3),
+                PHP_EOL;
             echo \str_pad($command, $maxLength + 2, ' ', STR_PAD_RIGHT),
                 '| ';
 

--- a/src/CommandLine/Command/ListProducts.php
+++ b/src/CommandLine/Command/ListProducts.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/ListProducts.php
+++ b/src/CommandLine/Command/ListProducts.php
@@ -25,6 +25,14 @@ class ListProducts implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/ListProducts.php
+++ b/src/CommandLine/Command/ListProducts.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
+    ConfigurableTrait,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class ListProducts
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class ListProducts implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class ListProducts implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,56 @@ class ListProducts implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('vendor', Operand::REQUIRED)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        /**
+         * @var string $vendor
+         */
+        $vendor = \array_shift($args);
+        $db = $this->getDatabase($this->configPath);
 
+        /** @var array<string, string> $data */
+        $data = $db->run(
+            "
+                SELECT
+                    v.name AS vendor,
+                    p.name AS product,
+                    p.created,
+                    p.modified
+                FROM
+                    herd_vendors v
+                LEFT JOIN
+                    herd_products p ON p.vendor = v.id
+                LEFT JOIN
+                    herd_product_updates u ON u.product = p.id
+                LEFT JOIN
+                    herd_history h ON u.history = h.id
+                WHERE
+                    v.name = ?
+            ",
+            $vendor
+        );
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
+
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode fact into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +95,22 @@ class ListProducts implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/ListProducts.php
+++ b/src/CommandLine/Command/ListProducts.php
@@ -121,6 +121,17 @@ class ListProducts implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'List products for vendor',
+            'usage' => 'shepherd list-products <vendor>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/ListProducts.php
+++ b/src/CommandLine/Command/ListProducts.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class ListProducts
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class ListProducts implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/ListUpdates.php
+++ b/src/CommandLine/Command/ListUpdates.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
+    ConfigurableTrait,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class ListUpdates
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class ListUpdates implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class ListUpdates implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,75 @@ class ListUpdates implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('vendor', Operand::REQUIRED),
+            new Operand('product', Operand::REQUIRED),
+            new Operand('search', Operand::OPTIONAL)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        $db = $this->getDatabase($this->configPath);
+        $query = "
+                SELECT
+                    v.name AS vendor,
+                    p.name AS product,
+                    h.contents AS history,
+                    h.hash,
+                    h.summaryhash,
+                    u.*
+                FROM
+                    herd_vendors v
+                LEFT JOIN
+                    herd_products p ON p.vendor = v.id
+                LEFT JOIN
+                    herd_product_updates u ON u.product = p.id
+                LEFT JOIN
+                    herd_history h ON u.history = h.id
+                WHERE
+                    v.name = ?
+                    AND p.name = ?
+            ";
+        /**
+         * @var string $vendor
+         * @var string $product
+         */
+        if (count($args) > 2) {
+            /** @var string $search */
+            list($vendor, $product, $search) = $args;
+            /** @var array<string, string> $data */
+            $data = $db->run(
+                $query . ' AND u.version LIKE ?',
+                $vendor,
+                $product,
+                $db->escapeLikeValue($search) . '%'
+            );
+        } else {
+            list($vendor, $product) = $args;
+            /** @var array<string, string> $data */
+            $data = $db->run(
+                $query,
+                $vendor,
+                $product
+            );
+        }
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
 
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode fact into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +114,22 @@ class ListUpdates implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/ListUpdates.php
+++ b/src/CommandLine/Command/ListUpdates.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/ListUpdates.php
+++ b/src/CommandLine/Command/ListUpdates.php
@@ -140,6 +140,17 @@ class ListUpdates implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'List updates for product',
+            'usage' => 'shepherd list-updates <vendor> <product>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/ListUpdates.php
+++ b/src/CommandLine/Command/ListUpdates.php
@@ -25,6 +25,14 @@ class ListUpdates implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/ListUpdates.php
+++ b/src/CommandLine/Command/ListUpdates.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class ListUpdates
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class ListUpdates implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -76,7 +76,7 @@ class ListVendors implements CommandInterface
                         name LIKE ?
                     ORDER BY name ASC
                 ",
-                $arg1
+                $db->escapeLikeValue($arg1) . '%'
             );
         }
 

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -25,6 +25,14 @@ class ListVendors implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -52,6 +52,7 @@ class ListVendors implements CommandInterface
     {
         $db = $this->getDatabase($this->configPath);
         if (empty($args)) {
+            /** @var array<string, string> $data */
             $data = $db->run(
                 "
                 SELECT

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class ListVendors
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class ListVendors implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
+    ConfigurableTrait,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class ListVendors
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class ListVendors implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class ListVendors implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,59 @@ class ListVendors implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('search', Operand::OPTIONAL)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        $db = $this->getDatabase($this->configPath);
+        if (empty($args)) {
+            $data = $db->run(
+                "
+                SELECT
+                    *
+                FROM
+                    herd_vendors
+                ORDER BY name ASC
+                "
+            );
+        } else {
+            /** @var string $arg1 */
+            $arg1 = \array_shift($args);
 
+            /** @var array<string, string> $data */
+            $data = $db->run(
+                "
+                    SELECT
+                        *
+                    FROM
+                        herd_vendors
+                    WHERE
+                        name LIKE ?
+                    ORDER BY name ASC
+                ",
+                $arg1
+            );
+        }
+
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
+
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode vendor list into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +98,22 @@ class ListVendors implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/ListVendors.php
+++ b/src/CommandLine/Command/ListVendors.php
@@ -125,6 +125,17 @@ class ListVendors implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'List/search vendors',
+            'usage' => 'shepherd list-vendors <search>?',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/Transcribe.php
+++ b/src/CommandLine/Command/Transcribe.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/Transcribe.php
+++ b/src/CommandLine/Command/Transcribe.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+use ParagonIE\Herd\Data\Local;
+use ParagonIE\Herd\Exception\{
+    EncodingError,
+    FilesystemException
+};
+use ParagonIE\Herd\Herd;
+use ParagonIE\Herd\History;
+
+/**
+ * Class Transcribe
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class Transcribe implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     * @throws EncodingError
+     * @throws FilesystemException
+     */
+    public function run(...$args): int
+    {
+        $history = new History(
+            new Herd(
+                new Local($this->getDatabase())
+            )
+        );
+        try {
+            $history->transcribe();
+        } catch (\Throwable $ex) {
+            echo $ex->getMessage(), PHP_EOL;
+            return 127;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/Command/Transcribe.php
+++ b/src/CommandLine/Command/Transcribe.php
@@ -32,6 +32,14 @@ class Transcribe implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      * @throws EncodingError

--- a/src/CommandLine/Command/Transcribe.php
+++ b/src/CommandLine/Command/Transcribe.php
@@ -102,6 +102,17 @@ class Transcribe implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'Update local history from Chronicle',
+            'usage' => 'shepherd transcribe',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/VendorKeys.php
+++ b/src/CommandLine/Command/VendorKeys.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
     DatabaseTrait

--- a/src/CommandLine/Command/VendorKeys.php
+++ b/src/CommandLine/Command/VendorKeys.php
@@ -124,6 +124,17 @@ class VendorKeys implements CommandInterface
      */
     public function usageInfo(): array
     {
-        return [];
+        return [
+            'name' => 'List public keys for vendor',
+            'usage' => 'shepherd vendor-keys <vendor>',
+            'options' => [
+                'Configuration file' => [
+                    'Examples' => [
+                        '-c /path/to/file',
+                        '--config=/path/to/file'
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/src/CommandLine/Command/VendorKeys.php
+++ b/src/CommandLine/Command/VendorKeys.php
@@ -25,6 +25,14 @@ class VendorKeys implements CommandInterface
     }
 
     /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array
+    {
+        return [];
+    }
+
+    /**
      * @param array<int, string> $args
      * @return int
      */

--- a/src/CommandLine/Command/VendorKeys.php
+++ b/src/CommandLine/Command/VendorKeys.php
@@ -3,13 +3,16 @@ declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine\Command;
 
 use GetOpt\{
+    GetOpt,
     Operand,
     Option
 };
 use ParagonIE\Herd\CommandLine\{
     CommandInterface,
+    ConfigurableTrait,
     DatabaseTrait
 };
+use ParagonIE\Herd\Exception\EncodingError;
 
 /**
  * Class VendorKeys
@@ -17,6 +20,7 @@ use ParagonIE\Herd\CommandLine\{
  */
 class VendorKeys implements CommandInterface
 {
+    use ConfigurableTrait;
     use DatabaseTrait;
 
     /**
@@ -24,7 +28,9 @@ class VendorKeys implements CommandInterface
      */
     public function getOptions(): array
     {
-        return [];
+        return [
+            new Option('c', 'config', GetOpt::REQUIRED_ARGUMENT)
+        ];
     }
 
     /**
@@ -32,16 +38,59 @@ class VendorKeys implements CommandInterface
      */
     public function getOperands(): array
     {
-        return [];
+        return [
+            new Operand('vendor', Operand::REQUIRED)
+        ];
     }
 
     /**
      * @param array<int, string> $args
      * @return int
+     * @throws \Exception
      */
     public function run(...$args): int
     {
+        /**
+         * @var string $vendor
+         */
+        $vendor = \array_shift($args);
+        $db = $this->getDatabase($this->configPath);
 
+        /** @var array<string, string> $data */
+        $data = $db->run(
+            "
+                SELECT
+                    v.name AS vendor,
+                    k.publickey,
+                    k.name,
+                    k.created,
+                    k.modified,
+                    h.contents AS history,
+                    h.hash,
+                    h.summaryhash
+                FROM
+                    herd_vendors v
+                LEFT JOIN
+                    herd_vendor_keys k ON k.vendor = v.id
+                LEFT JOIN
+                    herd_history h ON k.history_create = h.id
+                WHERE
+                    v.name = ?
+                    AND k.trusted
+            ",
+            $vendor
+        );
+        if (empty($data)) {
+            echo '[]', PHP_EOL;
+            exit(2);
+        }
+
+        /** @var string $encoded */
+        $encoded = \json_encode($data, JSON_PRETTY_PRINT);
+        if (!\is_string($encoded)) {
+            throw new EncodingError('Could not encode fact into a JSON string');
+        }
+        echo $encoded, PHP_EOL;
         return 0;
     }
 
@@ -49,11 +98,22 @@ class VendorKeys implements CommandInterface
      * Use the options provided by GetOpt to populate class properties
      * for this Command object.
      *
-     * @param array $args
+     * @param array<string, string> $args
      * @return self
+     * @throws \Exception
      */
     public function setOpts(array $args = [])
     {
+        if (isset($args['config'])) {
+            $this->setConfigPath($args['config']);
+        } elseif (isset($args['c'])) {
+            $this->setConfigPath($args['c']);
+        } else {
+            $this->setConfigPath(
+                \dirname(\dirname(\dirname(__DIR__))) .
+                '/data/config.json'
+            );
+        }
         return $this;
     }
 

--- a/src/CommandLine/Command/VendorKeys.php
+++ b/src/CommandLine/Command/VendorKeys.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine\Command;
+
+use GetOpt\Option;
+use ParagonIE\Herd\CommandLine\{
+    CommandInterface,
+    DatabaseTrait
+};
+
+/**
+ * Class VendorKeys
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+class VendorKeys implements CommandInterface
+{
+    use DatabaseTrait;
+
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int
+    {
+
+        return 0;
+    }
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = [])
+    {
+        return $this;
+    }
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array
+    {
+        return [];
+    }
+}

--- a/src/CommandLine/CommandInterface.php
+++ b/src/CommandLine/CommandInterface.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine;
+
+use GetOpt\Option;
+
+/**
+ * Interface CommandInterface
+ * @package ParagonIE\Herd\CommandLine
+ */
+interface CommandInterface
+{
+    /**
+     * @return array<int, Option>
+     */
+    public function getOptions(): array;
+
+    /**
+     * @param array<int, string> $args
+     * @return int
+     */
+    public function run(...$args): int;
+
+    /**
+     * Use the options provided by GetOpt to populate class properties
+     * for this Command object.
+     *
+     * @param array $args
+     * @return self
+     */
+    public function setOpts(array $args = []);
+
+    /**
+     * Get information about how this command should be used.
+     *
+     * @return array
+     */
+    public function usageInfo(): array;
+}

--- a/src/CommandLine/CommandInterface.php
+++ b/src/CommandLine/CommandInterface.php
@@ -2,7 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\Herd\CommandLine;
 
-use GetOpt\Option;
+use GetOpt\{
+    Operand,
+    Option
+};
 
 /**
  * Interface CommandInterface
@@ -14,6 +17,11 @@ interface CommandInterface
      * @return array<int, Option>
      */
     public function getOptions(): array;
+
+    /**
+     * @return array<int, Operand>
+     */
+    public function getOperands(): array;
 
     /**
      * @param array<int, string> $args

--- a/src/CommandLine/ConfigurableTrait.php
+++ b/src/CommandLine/ConfigurableTrait.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+namespace ParagonIE\Herd\CommandLine;
+use ParagonIE\Herd\Exception\FilesystemException;
+
+/**
+ * Trait ConfigurableTrait
+ * @package ParagonIE\Herd\CommandLine\Command
+ */
+trait ConfigurableTrait
+{
+    /** @var string $configPath */
+    public $configPath = '';
+
+    /**
+     * @param string $path
+     * @throws FilesystemException
+     * @return self
+     */
+    public function setConfigPath(string $path): self
+    {
+        if (!\file_exists($path)) {
+            throw new FilesystemException('Configuration file does not exist');
+        }
+        if (!\is_readable($path)) {
+            throw new FilesystemException('Configuration file cannot be read by the current user');
+        }
+        if (!\is_writable($path)) {
+            throw new FilesystemException('Configuration file cannot be written to by the current user');
+        }
+        $this->configPath = \realpath($path);
+        return $this;
+    }
+}

--- a/src/CommandLine/DatabaseTrait.php
+++ b/src/CommandLine/DatabaseTrait.php
@@ -51,9 +51,9 @@ trait DatabaseTrait
         }
         return Factory::create(
             (string) $data['database']['dsn'],
-            (string) $data['database']['username'] ?? '',
-            (string) $data['database']['password'] ?? '',
-            (array) $data['database']['options'] ?? []
+            (string) ($data['database']['username'] ?? ''),
+            (string) ($data['database']['password'] ?? ''),
+            (array) ($data['database']['options'] ?? [])
         );
     }
 }

--- a/src/CommandLine/DatabaseTrait.php
+++ b/src/CommandLine/DatabaseTrait.php
@@ -1,0 +1,59 @@
+<?php
+namespace ParagonIE\Herd\CommandLine;
+
+use ParagonIE\EasyDB\{
+    EasyDB,
+    Factory
+};
+use ParagonIE\Herd\Exception\{
+    EncodingError,
+    FilesystemException
+};
+
+/**
+ * Trait DatabaseTrait
+ * @package ParagonIE\Herd\CommandLine
+ */
+trait DatabaseTrait
+{
+    /**
+     * Get an EasyDB instance, given a configuration file.
+     *
+     * @param string $configPath
+     * @return EasyDB
+     * @throws EncodingError
+     * @throws FilesystemException
+     * @psalm-suppress MixedInferredReturnType I don't even know why
+     */
+    public function getDatabase(string $configPath = ''): EasyDB
+    {
+        if (!$configPath) {
+            $configPath = \dirname(\dirname(__DIR__)) . '/data/config.json';
+        }
+        if (!\is_readable($configPath)) {
+            throw new FilesystemException('Cannot read from configuration file');
+        }
+        /** @var string $config */
+        $config = \file_get_contents($configPath);
+        if (!\is_string($config)) {
+            throw new FilesystemException('Error reading from configuration file');
+        }
+        /** @var array<string, array<string, mixed>> $data */
+        $data = \json_decode($config, true);
+        if (!\is_array($data)) {
+            throw new EncodingError('Could not decode JSON file');
+        }
+        if (empty($data['database']['dsn'])) {
+            return Factory::create('sqlite::memory:');
+        }
+        if ($data['database']['dsn'] === 'sqlite') {
+            return Factory::create($data['database']['dsn']);
+        }
+        return Factory::create(
+            (string) $data['database']['dsn'],
+            (string) $data['database']['username'] ?? '',
+            (string) $data['database']['password'] ?? '',
+            (array) $data['database']['options'] ?? []
+        );
+    }
+}

--- a/src/CommandLine/README.md
+++ b/src/CommandLine/README.md
@@ -1,0 +1,3 @@
+# CommandLine
+
+This directory contains the CLI interface for Herd.

--- a/src/History.php
+++ b/src/History.php
@@ -88,6 +88,7 @@ class History
                         'hash' => $up['hash'],
                         'summaryhash' => $up['summary'],
                         'publickey' => $up['publickey'],
+                        'created' => $up['created'],
                         'signature' => $up['signature']
                     ]
                 );
@@ -98,7 +99,7 @@ class History
                 );
                 try {
                     $this->parseContentsAndInsert($up['contents'], (int)$historyID);
-                    $$db->update(
+                    $db->update(
                         'herd_history',
                         ['accepted' => true],
                         ['id' => $historyID]


### PR DESCRIPTION
Closes #1 

This is the beginning of a command line interface (tenatively named `shepherd`). The idea is to eventually expose this via `vendor/bin` in Composer.

Commands:

- [x] `transcribe`
- [x] `add-remote <url> <publickey>`
- [x] `fact <hash>`
- [x] `get-update <vendor> <name> <verson>`
- [x] `list-vendors <search_param>?`
- [x] `list-products <vendor>`
- [x] `list-updates <vendor> <product>`
- [x] `vendor-keys <vendor>`